### PR TITLE
Fix bind error message

### DIFF
--- a/scalajvm/app/helpers/BindableEnumeration.scala
+++ b/scalajvm/app/helpers/BindableEnumeration.scala
@@ -13,7 +13,7 @@ abstract class BindableEnumeration extends Enumeration { Self =>
             case Right(value) =>
               Self.values.find(_.toString.toLowerCase == value.toLowerCase) match {
                 case Some(v) => Right(v)
-                case None => Left(s"Unknown sort type '$value'")
+                case None => Left(s"Unknown parameter type '$value'")
               }
             case other => Left(s"Not found string value for key '$key'")
           }


### PR DESCRIPTION
That `sort` word left from the old days when `BindableEnumeration` was not generic enough and handled only sorting parameters. It should be replaced with more generic word.
