### PR TITLE
Content is not optional field of the quote DTO

### DIFF
--- a/scala/src/main/scala/ru/org/codingteam/loglist/dto/QuoteDTO.scala
+++ b/scala/src/main/scala/ru/org/codingteam/loglist/dto/QuoteDTO.scala
@@ -1,3 +1,3 @@
 package ru.org.codingteam.loglist.dto
 
-case class QuoteDTO(id: Long, time: Long, content: Option[String], rating: Int)
+case class QuoteDTO(id: Long, time: Long, content: String, rating: Int)

--- a/scalajvm/app/controllers/api/Quotes.scala
+++ b/scalajvm/app/controllers/api/Quotes.scala
@@ -24,5 +24,5 @@ object Quotes extends Controller {
     }
 
   private def buildQuoteDto(quote: Quote): QuoteDTO =
-    QuoteDTO(quote.id, quote.time.getMillis, quote.content, quote.rating)
+    QuoteDTO(quote.id, quote.time.getMillis, quote.content.getOrElse(""), quote.rating)
 }


### PR DESCRIPTION
uPickle translates Option[T] into array. That makes the response of `/api/quote/*` methods quite unintuitive. So in case quote doesn't have a content in the database for some reason we should treat the content as an empty string in the DTO.