### PR TITLE
Use the same design for license blocks as for quotes

### DIFF
--- a/scalajvm/app/views/licenses.scala.html
+++ b/scalajvm/app/views/licenses.scala.html
@@ -1,4 +1,4 @@
 @main("Log List", showMenus = false) {
     <h1 class="licenses-header">Licenses of components used in LogList</h1>
-    <ul class="menu plate"><li><span class="bold">RSS Icon</span>: from <a href="http://www.feedicons.com/">feedicons.com</a> via <a href="https://commons.wikimedia.org/wiki/File:Feed-icon.svg">WikiMedia</a>. Originally distributed by the Mozilla Foundation under a MPL/GPL/LGPL tri-license. SVG version that we use was reproduced by Matt Brett.</li></ul>
+    <div class="plate license-content"><span class="bold">RSS Icon</span>: from <a href="http://www.feedicons.com/">feedicons.com</a> via <a href="https://commons.wikimedia.org/wiki/File:Feed-icon.svg">WikiMedia</a>. Originally distributed by the Mozilla Foundation under a MPL/GPL/LGPL tri-license. SVG version that we use was reproduced by Matt Brett.</div>
 }

--- a/scalajvm/public/stylesheets/main.css
+++ b/scalajvm/public/stylesheets/main.css
@@ -37,6 +37,11 @@ strong {
     padding-top: 1em;
 }
 
+.license-content {
+    padding: 10px;
+    line-height: 1.3;
+}
+
 .highlight {
     color: #AAFF55
 }


### PR DESCRIPTION
#158 introduced a page with third-party licenses list, but the design of that page diverged a bit from the main page's. This PR corrects the disparity by styling license blocks the same way as quotes are styled.