### PR TITLE
#210: source URL support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -71,6 +71,8 @@ Send `GET` request to `/api/quote/xxxx`, where `xxxx` is quote id. Example:
 ```
 GET /api/quote/7921
 => { "id": "7921",
+     "source": "loglist.ru",
+     "sourceUrl": "http://loglist.ru/",
      "time": "1418549262553", # UTC timestamp
      "content": "<quote content>",
      "rating": 5 }
@@ -85,6 +87,8 @@ Send `GET` request to `/api/quote/random`. Example:
 ```
 GET /api/quote/random
 => { "id": "7921",
+     "source": "loglist.ru",
+     "sourceUrl": "http://loglist.ru/",
      "time": "1418549262553",
      "content": "<quote content>",
      "rating": 5 }
@@ -127,10 +131,14 @@ Send `GET` request to `/api/quote/list?limit=x&page=y&order=o&filter=f`, where:
 ```
 GET /api/quote/list?limit=10&page=1&filter=none&order=time
 => [{ "id": "7911",
+      "source": "loglist.ru",
+      "sourceUrl": "http://loglist.ru/",
       "time": "1301903967000",
       "content": "<quote text>",
       "rating": 0 },
     { "id": "7912",
+      "source": "loglist.ru",
+      "sourceUrl": "http://loglist.ru/",
       "time": "1301903967001",
       "content": "<quote text>",
       "rating": 0 }]

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -8,5 +8,6 @@ To access some site API, client should pass API token. To add an API token,
 execute the following SQL query:
 
 ```sql
-insert into api_key(source, key) values ('source tag', 'api-key')
+insert into api_key(source, key, source_url) values ('source tag', 'api-key', 'http://url')
+-- You may omit the URL, it will be null by default
 ```

--- a/scala/src/main/scala/ru/org/codingteam/loglist/dto/QuoteDTO.scala
+++ b/scala/src/main/scala/ru/org/codingteam/loglist/dto/QuoteDTO.scala
@@ -1,3 +1,3 @@
 package ru.org.codingteam.loglist.dto
 
-case class QuoteDTO(id: Long, source: String, time: Long, content: String, rating: Int)
+case class QuoteDTO(id: Long, source: String, sourceUrl: String, time: Long, content: String, rating: Int)

--- a/scalajvm/app/controllers/api/Quotes.scala
+++ b/scalajvm/app/controllers/api/Quotes.scala
@@ -45,7 +45,7 @@ object Quotes extends Controller with Cors {
     }
 
   private def buildQuoteDto(quote: Quote): QuoteDTO =
-    QuoteDTO(quote.id, quote.source, quote.time.getMillis, quote.content.getOrElse(""), quote.rating)
+    QuoteDTO(quote.id, quote.source, quote.sourceUrl.orNull, quote.time.getMillis, quote.content.getOrElse(""), quote.rating)
 
   private def json(text: String) = Ok(text).as("application/json; charset=utf-8")
 }

--- a/scalajvm/app/models/data/ApiKey.scala
+++ b/scalajvm/app/models/data/ApiKey.scala
@@ -2,10 +2,10 @@ package models.data
 
 import scalikejdbc._
 
-case class ApiKey(id: Long, key: String, source: String)
+case class ApiKey(id: Long, key: String, source: String, sourceUrl: Option[String])
 
 object ApiKey extends SQLSyntaxSupport[ApiKey] {
   override val tableName = "api_key"
   def apply(rs: WrappedResultSet) =
-    new ApiKey(rs.long("id"), rs.string("key"), rs.string("source"))
+    new ApiKey(rs.long("id"), rs.string("key"), rs.string("source"), rs.stringOpt("source_url"))
 }

--- a/scalajvm/app/models/data/Quote.scala
+++ b/scalajvm/app/models/data/Quote.scala
@@ -3,9 +3,16 @@ package models.data
 import org.joda.time.DateTime
 import scalikejdbc._
 
-case class Quote(id: Long, source: String, time: DateTime, content: Option[String], rating: Int)
+case class Quote(id: Long, source: String, sourceUrl: Option[String], time: DateTime, content: Option[String], rating: Int)
 object Quote extends SQLSyntaxSupport[Quote] {
   override val tableName = "quote"
+
   def apply(rs: WrappedResultSet): Quote =
-    new Quote(rs.long("id"), rs.string("source"), rs.jodaDateTime("time"), rs.stringOpt("content"), rs.int("rating"))
+    new Quote(
+      rs.long("id"),
+      rs.string("source"),
+      rs.stringOpt("source_url"),
+      rs.jodaDateTime("time"),
+      rs.stringOpt("content"),
+      rs.int("rating"))
 }

--- a/scalajvm/app/views/index.scala.html
+++ b/scalajvm/app/views/index.scala.html
@@ -55,8 +55,14 @@
                 <span>@quote.time</span>
             </div>
             <div class="quote-content plate">@quote.content.getOrElse("")</div>
-            @if(quote.source != "user") {
-                <div class="quote-source plate">(Источник: @quote.source)</div>
+            @(quote.source, quote.sourceUrl) match {
+                case ("user", _) => {}
+                case (source, None) => {
+                    <div class="quote-source plate">(Источник: @quote.source)</div>
+                }
+                case (source, Some(url)) => {
+                    <div class="quote-source plate">(Источник: <a href="@url">@quote.source</a>)</div>
+                }
             }
             <div class="mobile-only plate mobile-rating-panel">
                 @voting.ratingPanel(quote)

--- a/scalajvm/app/views/quote.scala.html
+++ b/scalajvm/app/views/quote.scala.html
@@ -13,8 +13,14 @@
             <span>@quote.time</span>
         </div>
         <div class="quote-content plate">@quote.content.getOrElse("")</div>
-        @if(quote.source != "user") {
-            <div class="quote-source plate">(Источник: @quote.source)</div>
+        @(quote.source, quote.sourceUrl) match {
+            case ("user", _) => {}
+            case (source, None) => {
+                <div class="quote-source plate">(Источник: @quote.source)</div>
+            }
+            case (source, Some(url)) => {
+                <div class="quote-source plate">(Источник: <a href="@url">@quote.source</a>)</div>
+            }
         }
         <div class="mobile-only plate mobile-rating-panel">
             @voting.ratingPanel(quote)

--- a/scalajvm/conf/evolutions/default/9.sql
+++ b/scalajvm/conf/evolutions/default/9.sql
@@ -1,0 +1,13 @@
+# --- !Ups
+alter table quote
+add column source_url varchar(128) null;
+
+alter table api_key
+add column source_url varchar(128) null;
+
+# --- !Downs
+alter table quote
+drop column source_url;
+
+alter table api_key
+drop column source_url;


### PR DESCRIPTION
Closes #210.

After merging and deploying that, I'm planning to manually update the quotes in the database with the following SQL script:

```sql
update api_key set source_url = 'https://t.me/xthon' where source = '@xthon';
update quote set source_url = 'http://loglist.ru/' where source = 'loglist.ru';
update quote set source_url = 'https://t.me/xthon' where source = '@xthon';
```

The reason I haven't included that script into a migration is that I consider that script a part of database administration and not the actual code maintaining.