### PR TITLE
#213: add site API link

### DIFF
--- a/scalajvm/app/views/main.scala.html
+++ b/scalajvm/app/views/main.scala.html
@@ -40,6 +40,7 @@
             <li>
                 <a href="@routes.Licenses.listLicenses()">Лицензии сторонних компонентов</a>
             </li>
+            <li><a href="https://github.com/codingteam/loglist/blob/master/docs/API.md">API сайта</a></li>
             <li><span class="highlight"><a href="https://github.com/codingteam/loglist">codingteam</a> ©</span> 2014&ndash;2017</li>
         </ul>
     </body>


### PR DESCRIPTION
It looks like this:

![image](https://user-images.githubusercontent.com/92793/28217786-85a23548-68e0-11e7-8b99-8934de215700.png)
↑ (desktop)

![image](https://user-images.githubusercontent.com/92793/28217797-94b6f190-68e0-11e7-90e8-f44c4203570c.png)
↑ (mobile)

Closes #213.