### PR TITLE
Transactional DDL in evolutions

### DIFF
--- a/scalajvm/conf/application.conf
+++ b/scalajvm/conf/application.conf
@@ -51,6 +51,7 @@ db.default.url=${DATABASE_URL}
 # ~~~~~
 # You can disable evolutions if needed
 # evolutionplugin=disabled
+evolutions.autocommit=false
 applyEvolutions.default=${APPLY_EVOLUTIONS_SILENTLY}
 
 # Logger


### PR DESCRIPTION
It turned out that so-called [transactional DDL](https://wiki.postgresql.org/wiki/Transactional_DDL_in_PostgreSQL:_A_Competitive_Analysis) support is disabled in Play evolutions by default. That's [documented](https://www.playframework.com/documentation/2.3.x/Evolutions); to enable it, we need to set `evolutions.autocommit=false`.

I think that we need to do that to avoid further confusion on failed evolutions in our code base.

I have reproduced the issue #198 and checked that it won't reappear with that change: the database doesn't get changed at all if any evolution fails.

Closes #198.