### PR TITLE
Update copyright year in main page template

### DIFF
--- a/scalajvm/app/views/main.scala.html
+++ b/scalajvm/app/views/main.scala.html
@@ -41,7 +41,7 @@
                 <a href="@routes.Licenses.listLicenses()">Лицензии сторонних компонентов</a>
             </li>
             <li><a href="https://github.com/codingteam/loglist/blob/master/docs/API.md">API сайта</a></li>
-            <li><span class="highlight"><a href="https://github.com/codingteam/loglist">codingteam</a> ©</span> 2014&ndash;2017</li>
+            <li><span class="highlight"><a href="https://github.com/codingteam/loglist">codingteam</a> ©</span> 2014&ndash;2018</li>
         </ul>
     </body>
 </html>


### PR DESCRIPTION
Decided not to update LICENSE.md because code hasn't been touched this year yet.